### PR TITLE
added function printMode so that ANT/MRX/SNA appear properly at fixed location

### DIFF
--- a/antuino_analyzer_27mhz_v2.ino
+++ b/antuino_analyzer_27mhz_v2.ino
@@ -133,8 +133,15 @@ const int PROGMEM vswr[] = {
 10 
 };
 
+void printMode(char s[]){
+    lcd.setCursor(13, 0);
+    lcd.print(s);
+}
+
 void printLine1(char *c){
     lcd.setCursor(0, 0);
+    // Just to clear any  trailing garbage from last print
+    strcat(c, "        "); 
     lcd.print(c);
 }
 
@@ -142,7 +149,6 @@ void printLine2(char *c){
   lcd.setCursor(0, 1);
   lcd.print(c);
 }
-
 
 
 int enc_prev_state = 3;
@@ -251,13 +257,20 @@ void updateDisplay() {
     strncat(c, &b[4], 3);
   }
   if (mode == MODE_ANTENNA_ANALYZER)
-    strcat(c, "  ANT");
+  {
+    printLine1(c );
+    printMode("ANT");
+  }
   else if (mode == MODE_MEASUREMENT_RX)
-    strcat(c, "  MRX");
+  {
+    printLine1(c);
+    printMode("MRX");
+   }
   else if (mode == MODE_NETWORK_ANALYZER)
-    strcat(c, "  SNA");
-  printLine1(c);
-
+   {
+      printLine1(c);
+      printMode("SNA");
+   }
   if (mode == MODE_ANTENNA_ANALYZER){
     return_loss = openReading(frequency) - analogRead(DBM_READING)/5;
     if (return_loss > 30)
@@ -856,5 +869,3 @@ void loop() {
     prev = r;
   }
 }
-
-


### PR DESCRIPTION
-- added function printMode so that ANT/MRX/SNA appear properly at fixed location

I observed that during lower bands, the mode ANT/MRX/SNA were not staying at a fixed place and were moving left keeping trailing garbage from previous display.
So I created a function printMode which will always print the mode always fixed at 13th location.

While redrawing the frequency, I have concatenated some additional space to printLine1() which will always clear any garbage from previous prints too. 

I have found one more issue in drawing the frequency. 
In lower frequencies like 1.100.100 in place of showing the complete it truncates and shows  1.100.10 .. I am trying to debug and will provide a fix soon.